### PR TITLE
Extract _Pitch class and Fix pitch number bug

### DIFF
--- a/src/test_music.py
+++ b/src/test_music.py
@@ -4,6 +4,26 @@ import music as ptr
 
 class TestNotes(TestCase):
 
+    def test_C4_maps_to_0(self):
+        # Arrange
+        n = ptr.Note('C4', 1.0)
+
+        # Act
+        pitch_number = n.pitch_number
+
+        # Assert
+        self.assertEqual(pitch_number, 0)
+
+    def test_C4_maps_to_0(self):
+        # Arrange
+        n = ptr.Note('C4', 1.0)
+
+        # Act
+        pitch_number = n.pitch_number
+
+        # Assert
+        self.assertEqual(pitch_number, 0)
+
     def test_init_sets_pitch_and_duration(self):
         # Arrange
         n = ptr.Note('C', 1.0)
@@ -13,7 +33,7 @@ class TestNotes(TestCase):
         duration = n.duration
 
         # Assert
-        self.assertEqual(pitch, 'C')
+        self.assertEqual(pitch, 'C4')
         self.assertEqual(duration, 1.0)
 
     def test_eq(self):
@@ -40,70 +60,3 @@ class TestRests(TestCase):
         # Assert
         self.assertEqual(pitch, None)
         self.assertEqual(duration, 1.0)
-
-class TestMeasures(TestCase):
-
-    def setUp(self):
-        ptr.key(ptr.Key.C_MAJOR)
-        ptr.time(ptr.Time.COMMON_TIME)
-
-    def test_init_without_key_or_time_raises_exception(self):
-
-        # Arrange
-        ptr.key(None)
-        ptr.time(None)
-
-        # Act
-        action = ptr.Measure
-
-        # Assert
-        self.assertRaises(Exception, action)
-    
-    def test_init_uses_global_key_and_time_signature(self):
-
-        # Act
-        m = ptr.Measure()
-
-        # Assert
-        self.assertEqual(m.key_signature, ptr.Key.C_MAJOR)
-        self.assertEqual(m.time_signature, ptr.Time.COMMON_TIME)
-
-    def test_extend_appends_all(self):
-
-        # Arrange
-        do = ptr.Note('C', 3/2)
-        re = ptr.Note('D', 1/2)
-        mi = ptr.Note('E', 3/2)
-
-        notes = [do, re, mi]
-
-        m = ptr.Measure()
-
-        # Act
-        m.extend(notes)
-
-        # Assert
-        self.assertEqual(m[0], do)
-        self.assertEqual(m[1.5], re)
-        self.assertEqual(m[2], mi)
-
-    def test_append_appends(self):
-        # Arrange
-        ptr.key(ptr.Key.C_MAJOR)
-        ptr.time(ptr.Time.COMMON_TIME)
-
-        do = ptr.Note('C', 3/2)
-        re = ptr.Note('D', 1/2)
-        mi = ptr.Note('E', 3/2)
-
-        m = ptr.Measure()
-
-        # Act
-        m.append(do)
-        m.append(re)
-        m.append(mi)
-
-        # Assert
-        self.assertEqual(m[0], do)
-        self.assertEqual(m[1.5], re)
-        self.assertEqual(m[2], mi)

--- a/src/test_pitch.py
+++ b/src/test_pitch.py
@@ -1,0 +1,62 @@
+import unittest
+from music import _Pitch
+
+
+class TestPitch(unittest.TestCase):
+    def test_getters_work(self):
+        # arrange
+
+        p = _Pitch('A', 'bb', 4)
+
+        # act
+        l = p.letter
+        accs = p.accidentals
+        o = p.octave
+
+        # assert
+        self.assertEqual(l, 'A')
+        self.assertEqual(accs, 'bb')
+        self.assertEqual(o, 4)
+
+    def test_pitch_to_int(self):
+        # arrange
+        p = _Pitch('A', 'bb', 4)
+
+        # act
+        i = int(p)
+
+        # assert
+        self.assertEqual(i, -5)
+
+    def test_accidental_offset_flats(self):
+
+        # arrange
+        p = _Pitch('C', 'bbbbbbbbbb', 4)
+
+        # act
+        accidentals = p.accidentals
+
+        # assert
+        self.assertEqual(accidentals, 'bbbbbbbbbb')
+
+    def test_accidental_offset_sharp(self):
+
+        # arrange
+        p = _Pitch('C', '#', 4)
+
+        # act
+        accidentals = p.accidentals
+
+        # assert
+        self.assertEqual(accidentals, '#')
+
+    def test_accidental_offset_double_sharp(self):
+
+        # arrange
+        p = _Pitch('C', '##', 4)
+
+        # act
+        accidentals = p.accidentals
+
+        # assert
+        self.assertEqual(accidentals, 'X')


### PR DESCRIPTION
Closes #9. Moves pitch definition into a separate class. Each `Note` instance now has a member variable `_pitch` of type `_Pitch`, defined by 3 variables, `letter`, `accidental_offset`, and `octave`.
