### PR TITLE
Use PITCHR_PATH env variable for saving and loading the ML model

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Other dependencies that must be installed (available via your package manager):
   * libasound2
   * lilypond
 
+Pitchr downloads models to `~/.pitchr/`. Set the `PITCHR_PATH` environment variable to change this behavior.
+
 ## Documentation
 Documentation is hosted on Github Pages [here](https://thedpws.github.io/pitcher/)
 

--- a/pitchr/harmony_maker.py
+++ b/pitchr/harmony_maker.py
@@ -152,6 +152,7 @@ def verify_model():
     MODEL_PATH = PITCHR_PATH + '/saved_model/my_model'
 
     if True or not os.path.exists(MODEL_PATH):
+        print('Downloading required models...')
         os.makedirs(MODEL_PATH, exist_ok=True)
         os.makedirs(MODEL_PATH + '/variables/', exist_ok=True)
 

--- a/pitchr/harmony_maker.py
+++ b/pitchr/harmony_maker.py
@@ -151,7 +151,7 @@ def build_harmony(melody_staff):
 def verify_model():
     MODEL_PATH = PITCHR_PATH + '/saved_model/my_model'
 
-    if True or not os.path.exists(MODEL_PATH):
+    if not os.path.exists(MODEL_PATH):
         print('Downloading required models...')
         os.makedirs(MODEL_PATH, exist_ok=True)
         os.makedirs(MODEL_PATH + '/variables/', exist_ok=True)

--- a/pitchr/harmony_maker.py
+++ b/pitchr/harmony_maker.py
@@ -15,8 +15,8 @@ import shutil
 try:
     PITCHR_PATH = os.environ["PITCHR_PATH"]
 except KeyError:
-    print('Environment variable "PITCHR_PATH" is unset. Using default path "~/.pitchr"')
-    PITCHR_PATH = '~/.pitchr'
+    print(f'Environment variable "PITCHR_PATH" is unset. Using default path "{os.environ["HOME"]}/.pitchr"')
+    PITCHR_PATH = os.environ["HOME"] + '/.pitchr'
 
 
 def prepare_np(melody_np):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,58 @@
+
+import unittest
+from pitchr import harmony_maker
+import importlib
+import shutil
+from pitchr import *
+
+import os
+
+class TestModel(unittest.TestCase):
+
+    def setUp(self):
+        os.environ['HOME'] = os.getcwd()
+
+
+    def test_when_path_unset_uses_default(self):
+        # Arrange
+        del os.environ['PITCHR_PATH']
+
+
+        # Act
+        importlib.reload(harmony_maker)
+
+        # Assert
+        self.assertEqual(harmony_maker.PITCHR_PATH, os.environ['HOME'] + '/.pitchr')
+
+    def test_when_path_set_uses_path(self):
+        # Arrange
+        os.environ['PITCHR_PATH'] = os.environ['HOME'] + '/.newpitchr'
+
+
+        # Act
+        importlib.reload(harmony_maker)
+
+
+        # Assert
+        self.assertEqual(harmony_maker.PITCHR_PATH, os.environ['HOME'] + '/.newpitchr')
+
+    def test_when_model_does_not_exist_is_downloaded(self):
+
+        # Arrange
+        os.environ['PITCHR_PATH'] = os.environ['HOME'] + '/.newpitchr'
+
+        if os.path.exists(os.environ['HOME'] + '/.newpitchr'):
+            shutil.rmtree(os.environ['HOME'] + '/.newpitchr')
+
+        importlib.reload(harmony_maker)
+
+        # Preconditions Assertions
+        self.assertFalse(os.path.exists(os.environ['HOME'] + '/.newpitchr/saved_model'))
+
+
+        # Act
+        h = harmony_maker.build_harmony(Staff([Measure([Note('C', 1.0)])]))
+
+        path = os.environ['HOME'] + '/.newpitchr/saved_model/my_model/saved_model.pb'
+        # Assert
+        self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
This fixes a bug where pitchr gotten by pip searches for a pitchr directory in the current working directory.